### PR TITLE
Revert "Nuke Megvii as it conflicts with faceunlock"

### DIFF
--- a/megvii/Android.bp
+++ b/megvii/Android.bp
@@ -1,0 +1,23 @@
+//
+// Copyright (C) 2022 The LineageOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+cc_defaults {
+    name: "libMegviiFacepp_defaults",
+    vendor: true,
+    srcs: [
+        "megvii.c",
+    ],
+}
+
+cc_library_shared {
+    name: "libMegviiFacepp-0.5.2",
+    defaults: ["libMegviiFacepp_defaults"],
+}
+
+cc_library_shared {
+    name: "libmegface",
+    vendor: true,
+}

--- a/megvii/megvii.c
+++ b/megvii/megvii.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 The LineageOS Project
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
+
+static int stub_fail() {
+    return -1;
+}
+
+static char *stub_fail_str() {
+    return "stub";
+}
+
+void *mg_facepp[] = {
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail_str,
+    &stub_fail_str,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+    &stub_fail,
+};


### PR DESCRIPTION
A13 doesn't have faceunlock yet and some Xiaomi devices still need Megvii stub libs.

This reverts commit dfd584a2bdd26bee9bdea43538540d319b7ce141.